### PR TITLE
Makes grunt process stop after finished

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   },
   "homepage": "https://github.com/h0lyalg0rithm/grunt-mandrill",
   "dependencies": {
+    "async": "^1.5.2",
     "lodash": "^2.4.1",
     "mandrill-api": "^1.0.40"
   },
   "devDependencies": {
+    "async": "^1.5.2",
     "grunt": "~0.4.2",
     "mandrill-api": "^1.0.40"
   },

--- a/tasks/mandrill.js
+++ b/tasks/mandrill.js
@@ -1,5 +1,6 @@
 var mandrill = require('mandrill-api'),
-    _        = require('lodash');
+    _        = require('lodash'),
+    async    = require('async');
 
 
 
@@ -21,21 +22,26 @@ module.exports = function(grunt){
     // If file is present
     if(this.filesSrc.length > 0){
       _.each(this.filesSrc,function(path){
-          options.body = grunt.file.read(path);
-          send_to_many(grunt,mandrill,to,options);
+        options.body = grunt.file.read(path);
+        send_to_many(grunt,mandrill,to,options,done);
       });
     }else{
-      send_to_many(grunt,mandrill,to,options);
+      send_to_many(grunt,mandrill,to,options,done);
     }
   });
 }
 
-function send_to_many(grunt,client,recipients,options){
-  _.each(recipients, function(recipient){
-    send_email(grunt,client,recipient,options);
+function send_to_many(grunt,client,recipients,options,done){
+  async.each(recipients, function(recipient,callback){
+    send_email(grunt,client,recipient,options,callback);
+  }, function(err){
+    if(err) {
+      return done(false);
+    }
+    done();
   });
 }
-function send_email(grunt,client,recipient,options){
+function send_email(grunt,client,recipient,options,callback){
   var message = {
     "html": options.body,
     "subject": options.subject,
@@ -48,11 +54,14 @@ function send_email(grunt,client,recipient,options){
       "Reply-To": options.sender
     }
   };
+
   client.messages.send({"message": message, "async": options.async}, function(result) {
       grunt.log.writeln('Sent email msg to ' + result[0].email);
+      callback();
   }, function(e) {
       // Mandrill returns the error as an object with name and message keys
       grunt.log.writeln('A mandrill error occurred: ' + e.name + ' - ' + e.message);
       // A mandrill error occurred: Unknown_Subaccount - No subaccount exists with the id 'customer-123'
+      callback(e.message);
   });
 }


### PR DESCRIPTION
Calls `done()` after process is finished. Needed to add `async.each` to handle async function.
This fixes https://github.com/h0lyalg0rithm/grunt-mandrill/issues/3.
